### PR TITLE
Split meteor install and app build steps on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ EXPOSE        80
 
 ENTRYPOINT    sh /tupperware/scripts/start_app.sh
 
+ONBUILD COPY  ./.meteor/release  /app/.meteor/release
+ONBUILD COPY  ./*.json  /app/
+
+ONBUILD RUN   sh /tupperware/scripts/on_build.sh install
+
 ONBUILD COPY  ./ /app
 
-ONBUILD RUN   sh /tupperware/scripts/on_build.sh
+ONBUILD RUN   sh /tupperware/scripts/on_build.sh build

--- a/includes/scripts/on_build.sh
+++ b/includes/scripts/on_build.sh
@@ -4,7 +4,7 @@ BASEDIR=`dirname $0`
 
 . $BASEDIR/_common.sh
 
-node $TUPPERBUILD_DIR/main.js
+node $TUPPERBUILD_DIR/main.js $1
 check_code $?
 
 rm -rf /tmp/*

--- a/includes/tupperbuild/main.js
+++ b/includes/tupperbuild/main.js
@@ -309,15 +309,21 @@ function printDone (done) {
   done();
 }
 
-async.series([
-  printBanner,
-  checkCopyPath,
-  extractTupperwareJson,
-  installAppDeps,
-  downloadMeteorInstaller,
-  installMeteor,
-  buildApp,
-  cleanMeteor,
-  npmInstall,
-  printDone
-]);
+if (process.argv[2] == "install") {
+  async.series([
+    checkCopyPath,
+    extractTupperwareJson,
+    installAppDeps,
+    downloadMeteorInstaller,
+    installMeteor
+  ]);
+} else {
+  async.series([
+    printBanner,
+    extractTupperwareJson,
+    buildApp,
+    cleanMeteor,
+    npmInstall,
+    printDone
+  ]);
+}


### PR DESCRIPTION
By running the meteor install steps before copying the whole app we can make use of Docker's cache and avoid having to download & install meteor every time the app changes.
