### PR TITLE
Update Node version for Meteor 1.4 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM          debian:jessie
 MAINTAINER    Chris Wessels (https://github.com/chriswessels)
 
-ENV           NODE_VERSION="0.10.43" PHANTOMJS_VERSION="2.1.1" IMAGEMAGICK_VERSION="8:6.8.9.9-5"
+ENV           NODE_VERSION="4.4.7" PHANTOMJS_VERSION="2.1.1" IMAGEMAGICK_VERSION="8:6.8.9.9-5"
 
 COPY          includes /tupperware
 


### PR DESCRIPTION
Astonishingly, the Meteor 1.4 actually happened, and brought a not-ancient version of node!
