### PR TITLE
Allow custom server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ Assuming you have Docker running, you can build an image of your Meteor.js app b
 
 ## Running your app image
 
-The root process of the image will be set to the Node.js entrypoint for your Meteor application, so you can pass runtime settings straight into `docker run -e`, or bake them into your image with `ENV` directives in your Dockerfile. Node.js will listen on port 80 inside the container, but you can bind this to any port on the host.
+The root process of the image will be set to the Node.js entrypoint for your Meteor application, so you can pass runtime settings straight into `docker run -e`, or bake them into your image with `ENV` directives in your Dockerfile.
+
+Node.js will listen on port 80 inside the container, but you can bind this to any port on the host. You can also specify a different internal port if you need to like this:
+
+    FROM    quay.io/chriswessels/meteor-tupperware
+    ENV     PORT=8080
 
 Example of passing options into `docker run` at runtime:
 

--- a/includes/scripts/start_app.sh
+++ b/includes/scripts/start_app.sh
@@ -9,7 +9,9 @@ if [ ! -f $OUTPUT_DIR/bundle/main.js ]; then
   exit 1
 fi
 
-export PORT=80
+if [ -z "$PORT" ]; then
+  export PORT=80
+fi
 
 if [ -z "$NODE_ENV" ]; then
   export NODE_ENV="production"
@@ -19,6 +21,6 @@ if [ -z "$METEOR_ENV" ]; then
   export METEOR_ENV="production"
 fi
 
-echo "[-] meteor-tupperware is starting your application with NODE_ENV=$NODE_ENV and METEOR_ENV=$METEOR_ENV..."
+echo "[-] meteor-tupperware is starting your application with NODE_ENV=$NODE_ENV and METEOR_ENV=$METEOR_ENV on port $PORT..."
 
 exec node $OUTPUT_DIR/bundle/main.js "$@"


### PR DESCRIPTION
This change enables writing a Dockerfile like this:

```
FROM    quay.io/chriswessels/meteor-tupperware
ENV     PORT=8080
```

Which will run the app server on internal port 8080 instead of the default 80. The default is still 80, so this is backwards compatible. Note that I left EXPOSE 80 since that is mostly informational. Any port you publish is exposed automatically, and exposed ports are not automatically published.